### PR TITLE
ci: make the format job actually fail on unformatted code

### DIFF
--- a/.github/workflows/static-code-checks.yml
+++ b/.github/workflows/static-code-checks.yml
@@ -29,9 +29,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Format
+      - name: Check format
         run: |
-          make format
+          make check-format
 
   lint:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
-.PHONY: lint check format test docs all
+.PHONY: lint check-format format test docs all
 
 format:
-	black .
 	ruff format .
+
+check-format:
+	ruff format --check .
 
 lint:
 	pylint deribit_wrapper
@@ -13,4 +15,4 @@ test:
 docs:
 	pydocstyle
 
-all: lint check format test docs
+all: lint check-format test docs

--- a/dev_scripts/debug_account_management.py
+++ b/dev_scripts/debug_account_management.py
@@ -76,9 +76,9 @@ def debug_api_keys():
     print("Enabled API key successfully.")
     account_management.remove_api_key(new_key_id)
     new_api_keys = account_management.list_api_keys()
-    assert (
-        new_key_id not in new_api_keys["id"]
-    ), "New key id still in active API keys list"
+    assert new_key_id not in new_api_keys["id"], (
+        "New key id still in active API keys list"
+    )
     print("API key removed successfully.")
 
 
@@ -109,9 +109,9 @@ def debug_margin_model():
     new_margin_model: MarginModelType = "segregated_sm"
     account_management.change_margin_model(new_margin_model)
     edited_margin_models = account_management.get_margin_model()
-    assert (
-        edited_margin_models["margin_model"] == new_margin_model
-    ).all(), f"Margin model not changed to {new_margin_model}."
+    assert (edited_margin_models["margin_model"] == new_margin_model).all(), (
+        f"Margin model not changed to {new_margin_model}."
+    )
     print(
         f"Margin model changed to {new_margin_model} successfully. Reverting to {current_margin_model}."
     )
@@ -119,7 +119,7 @@ def debug_margin_model():
     change_is_possible = account_management.check_if_margin_model_change_is_possible(
         "cross_pm"
     )
-    print(f'Change to cross_pm is {"" if change_is_possible else "not "}possible.')
+    print(f"Change to cross_pm is {'' if change_is_possible else 'not '}possible.")
 
 
 def run():

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,5 @@ pyflakes==3.4.0
 pylint==4.0.4
 pytest==9.0.1
 pytest-mock==3.15.1
-black==26.3.1
 ruff==0.14.7
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -68,12 +68,13 @@ def test_authentication_failure_leads_to_exception(mock_request, auth_instance):
 def test_get_new_token_retrieves_new_token():
     mock_response = token_mock_response
 
-    with patch(
-        "deribit_wrapper.authentication.Authentication._request"
-    ) as mock_request, patch(
-        "deribit_wrapper.authentication.Authentication.create_new_scope",
-        return_value="session:fixed_session_name",
-    ) as mock_create_new_scope:
+    with (
+        patch("deribit_wrapper.authentication.Authentication._request") as mock_request,
+        patch(
+            "deribit_wrapper.authentication.Authentication.create_new_scope",
+            return_value="session:fixed_session_name",
+        ) as mock_create_new_scope,
+    ):
         mock_request.return_value = mock_response
 
         auth = Authentication(


### PR DESCRIPTION
## Problem

The `format` CI job runs `make format`, which executes `black .` and `ruff format .` — both **reformat in place and always exit 0**. Unformatted code can never fail the gate (proof: `ruff format --check .` fails on `main` today for 2 files).

On top of that, black and ruff format disagree on assert-statement style, so with both in check mode no on-disk state can pass.

## Fix

- Standardize on **ruff format** as the single formatter. It ran last in `make format`, so the codebase's on-disk style is already ruff's; black is removed from `requirements-dev.txt` (the open Dependabot black bump can be closed once this merges).
- New `make check-format` target (`ruff format --check .`); the CI job runs that instead of the in-place formatter. `make format` stays for local use.
- Reformat the 2 files that were silently out of compliance.
- Fix `make all`, which referenced a nonexistent `check` target.

Part of the repo-health series (item 2).