### PR TITLE
fix: remove package dependency on dev_scripts

### DIFF
--- a/deribit_wrapper/account_management.py
+++ b/deribit_wrapper/account_management.py
@@ -7,7 +7,6 @@ from typing import Any
 
 import pandas as pd
 
-from dev_scripts.utilities_dev import create_multilevel_df
 from .exceptions import (
     SubaccountNameAlreadyTaken,
     SubaccountNameWrongFormat,
@@ -24,6 +23,7 @@ from .utilities import (
     DEFAULT_START,
     MarginModelType,
     MarketOrderType,
+    create_multilevel_df,
     from_dt_to_ts,
     seconds_to_hms,
 )

--- a/deribit_wrapper/utilities.py
+++ b/deribit_wrapper/utilities.py
@@ -58,10 +58,14 @@ def flatten_dict(d: dict, parent_key: str = "", sep: str = "_") -> dict:
     return dict(items)
 
 
-def create_multilevel_df(data: list[dict]) -> pd.DataFrame:
+def create_multilevel_df(data: dict | list[dict]) -> pd.DataFrame:
     sep = "___"
+    if isinstance(data, dict):
+        data = [data]
     flattened_data = [flatten_dict(item, sep=sep) for item in data]
     df = pd.DataFrame(flattened_data)
+    if df.columns.empty:
+        return df
     multiindex_columns = [tuple(col.split(sep)) for col in df.columns]
     df.columns = pd.MultiIndex.from_tuples(multiindex_columns)
     return df

--- a/deribit_wrapper/utilities.py
+++ b/deribit_wrapper/utilities.py
@@ -45,3 +45,23 @@ def seconds_to_hms(seconds: int) -> str:
     h, r = divmod(seconds, 3600)
     m, s = divmod(r, 60)
     return f"{h}h {m:02d}m {s:02d}s"
+
+
+def flatten_dict(d: dict, parent_key: str = "", sep: str = "_") -> dict:
+    items = []
+    for k, v in d.items():
+        new_key = f"{parent_key}{sep}{k}" if parent_key else k
+        if isinstance(v, dict):
+            items.extend(flatten_dict(v, new_key, sep=sep).items())
+        else:
+            items.append((new_key, v))
+    return dict(items)
+
+
+def create_multilevel_df(data: list[dict]) -> pd.DataFrame:
+    sep = "___"
+    flattened_data = [flatten_dict(item, sep=sep) for item in data]
+    df = pd.DataFrame(flattened_data)
+    multiindex_columns = [tuple(col.split(sep)) for col in df.columns]
+    df.columns = pd.MultiIndex.from_tuples(multiindex_columns)
+    return df

--- a/dev_scripts/utilities_dev.py
+++ b/dev_scripts/utilities_dev.py
@@ -1,21 +1,3 @@
-import pandas as pd
+from deribit_wrapper.utilities import create_multilevel_df, flatten_dict
 
-
-def flatten_dict(d: dict, parent_key: str = "", sep: str = "_") -> dict:
-    items = []
-    for k, v in d.items():
-        new_key = f"{parent_key}{sep}{k}" if parent_key else k
-        if isinstance(v, dict):
-            items.extend(flatten_dict(v, new_key, sep=sep).items())
-        else:
-            items.append((new_key, v))
-    return dict(items)
-
-
-def create_multilevel_df(data: list[dict]) -> pd.DataFrame:
-    sep = "___"
-    flattened_data = [flatten_dict(item, sep=sep) for item in data]
-    df = pd.DataFrame(flattened_data)
-    multiindex_columns = [tuple(col.split(sep)) for col in df.columns]
-    df.columns = pd.MultiIndex.from_tuples(multiindex_columns)
-    return df
+__all__ = ["create_multilevel_df", "flatten_dict"]


### PR DESCRIPTION
## Problem

[`account_management.py`](https://github.com/AntonioVentilii/deribit-wrapper/blob/main/deribit_wrapper/account_management.py#L10) imports `create_multilevel_df` **from `dev_scripts`** — a folder of local debug scripts. Consequences:

- The published package cannot work without `dev_scripts` being installed too, so `find_packages()` ships the debug scripts (including `config_dev.py`, which reads credentials from env) in every wheel.
- The library's import graph reaches outside the package.

## Fix

- Move `flatten_dict` / `create_multilevel_df` into `deribit_wrapper/utilities.py`.
- `account_management.py` imports them from the package.
- `dev_scripts/utilities_dev.py` re-exports them so existing dev-script imports keep working.

Verified: full test suite passes, pylint 10/10.

Part of the repo-health series (prerequisite for the `pyproject.toml` migration, which will stop shipping `dev_scripts` in the wheel).