### PR TITLE
ci: add coverage reporting to the test run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ lint:
 	pylint deribit_wrapper
 
 test:
-	pytest
+	pytest --cov=deribit_wrapper --cov-report=term-missing
 
 docs:
 	pydocstyle

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ pydocstyle==6.3.0
 pyflakes==3.4.0
 pylint==4.0.4
 pytest==9.0.1
+pytest-cov==7.1.0
 pytest-mock==3.15.1
 black==26.3.1
 ruff==0.14.7


### PR DESCRIPTION
Adds `pytest-cov` and wires it into `make test` (`--cov=deribit_wrapper --cov-report=term-missing`), so every CI test job prints per-module line coverage.

Current baseline: **35% overall** — `market_data` 20%, `account_management` 21%, `trading` 22%. The companion test PRs in this series raise those; this PR just makes the number visible.

Part of the repo-health series (item 4.1).