### PR TITLE
fix: unbreak the release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,12 +16,15 @@ jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-24.04
+    # Skip (instead of fail) until the release bot app is configured on this
+    # repo: RELEASE_BOT_APP_ID variable + RELEASE_BOT_PRIVATE_KEY secret.
+    if: ${{ vars.RELEASE_BOT_APP_ID != '' && secrets.RELEASE_BOT_PRIVATE_KEY != '' }}
     steps:
       - name: Generate bot token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          client-id: ${{ vars.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Run release-please


### PR DESCRIPTION
The first Release Please run on `main` failed: `create-github-app-token` v3 deprecates `app-id` in favor of `client-id`, and the bot credentials weren't configured on this repo yet, so the required input was empty.

- Switched to the `client-id` input (numeric App IDs are accepted there; kills the deprecation warnings too).
- The job now **skips instead of failing** while the bot isn't configured, so pushes to `main` stay green until setup is complete.
- I've already created the `RELEASE_BOT_APP_ID` repo variable (`4365677`, same App as icdc-core — it's not a secret).

## Remaining setup (only you can do these)
1. Add the `RELEASE_BOT_PRIVATE_KEY` secret (same key as icdc-core; secrets can't be copied between repos).
2. Install the release bot App on this repository (GitHub → Settings → Applications, or the App's install page).

Once both are in place, the next push to `main` opens the first release PR automatically.