### PR TITLE
fix: remove invalid job-level if from the release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,9 +16,6 @@ jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-24.04
-    # Skip (instead of fail) until the release bot app is configured on this
-    # repo: RELEASE_BOT_APP_ID variable + RELEASE_BOT_PRIVATE_KEY secret.
-    if: ${{ vars.RELEASE_BOT_APP_ID != '' && secrets.RELEASE_BOT_PRIVATE_KEY != '' }}
     steps:
       - name: Generate bot token
         id: app-token


### PR DESCRIPTION
The Release Please workflow is currently **unparseable on main** — dispatching it returns:

```
Unrecognized named-value: 'secrets'. Located at position 34 within expression:
vars.RELEASE_BOT_APP_ID != '' && secrets.RELEASE_BOT_PRIVATE_KEY != ''
```

My mistake in #91: the `secrets` context isn't available in `jobs.<job_id>.if` (only `github`, `needs`, `vars`, `inputs` are).

The guard existed only to keep things green while the bot credentials were missing. They're configured now (`RELEASE_BOT_APP_ID` variable + `RELEASE_BOT_PRIVATE_KEY` secret, app verified as having access to this repo), so it's removed rather than rewritten — leaving the workflow identical in shape to the sibling repos. The stale comment above it goes too.

Validated the YAML parses locally; the workflow will be dispatchable again once this lands.