### PR TITLE
fix: use pre-1.0 version bumping for releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,60 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
+  "pull-request-title-pattern": "chore(release): v${version}",
   "release-type": "python",
   "include-v-in-tag": true,
+  "changelog-sections": [
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "perf",
+      "section": "Performance Improvements"
+    },
+    {
+      "type": "deps",
+      "section": "Dependencies"
+    },
+    {
+      "type": "revert",
+      "section": "Reverts"
+    },
+    {
+      "type": "refactor",
+      "section": "Code Refactoring"
+    },
+    {
+      "type": "docs",
+      "section": "Documentation"
+    },
+    {
+      "type": "build",
+      "section": "Build System"
+    },
+    {
+      "type": "ci",
+      "section": "Continuous Integration"
+    },
+    {
+      "type": "test",
+      "section": "Tests"
+    },
+    {
+      "type": "style",
+      "section": "Styles"
+    },
+    {
+      "type": "chore",
+      "section": "Miscellaneous Chores"
+    }
+  ],
   "packages": {
     ".": {
       "package-name": "deribit_wrapper",


### PR DESCRIPTION
The config was missing the pre-1.0 bump rules, so release-please applied full semver: the queued release PR #95 proposes **0.7.0** off `feat:` commits, and a `feat!:` would have jumped straight to **1.0.0**.

While below 1.0.0 the intended behavior is:
- breaking change → **minor** (`bump-minor-pre-major`)
- feature → **patch** (`bump-patch-for-minor-pre-major`)

Both flags added, matching icdc-core, open-cloud, vici-cockpit, vici-cockpit-solveband and ombrellone. Also adopts the same `chore(release): v${version}` PR title pattern and the full `changelog-sections` list those repos use, so release notes group by type (Features / Bug Fixes / Documentation / …) instead of only showing feat+fix.

Effect on the queued release: after this merges and the workflow re-runs, #95 should re-propose **0.6.1** instead of 0.7.0.

JSON validated locally.