### PR TITLE
fix: simulated mode also suppresses close_position and cancel_orders

### DIFF
--- a/deribit_wrapper/trading.py
+++ b/deribit_wrapper/trading.py
@@ -13,6 +13,8 @@ from progressbar import progressbar
 from .account_management import AccountManagement
 from .utilities import DEFAULT_END, DEFAULT_START, OrdersType
 
+SIMULATION_INFO = "SIMULATION MODE - no trade executed"
+
 
 class Trading(AccountManagement):
     """Place, query, and cancel orders; simulated=True builds order results locally instead of submitting them."""
@@ -211,7 +213,7 @@ class Trading(AccountManagement):
             return {}
         if self.simulated:
             ret = {
-                "info": "SIMULATION MODE - no trade executed",
+                "info": SIMULATION_INFO,
                 "timestamp": int(time.time() * 1e3),
                 "kind": self.get_kind(asset),
                 "instrument_name": asset,
@@ -280,7 +282,15 @@ class Trading(AccountManagement):
         return ret
 
     def close_position(self, asset: str, limit: float | int = None) -> dict:
-        """Close a position at market, or at a limit price if given."""
+        """Close a position at market, or at a limit price if given; simulated when simulated=True."""
+        if self.simulated:
+            return {
+                "info": SIMULATION_INFO,
+                "timestamp": int(time.time() * 1e3),
+                "instrument_name": asset,
+                "type": "market" if limit is None else "limit",
+                "price": limit if limit is not None else self.last_price(asset),
+            }
         uri = self.__CLOSE_POSITION
         params = {
             "instrument_name": asset,
@@ -293,6 +303,8 @@ class Trading(AccountManagement):
         return ret
 
     def _cancel_by_label(self, label: str, currency: str | list[str] = None) -> dict:
+        if self.simulated:
+            return {"info": SIMULATION_INFO, "label": label, "currency": currency}
         uri = self.__CANCEL_BY_LABEL
         params = {
             "label": label,
@@ -317,6 +329,13 @@ class Trading(AccountManagement):
         """Cancel orders by label, or by currency, kind, and type."""
         if label is not None:
             return self._cancel_by_label(label, currency)
+        if self.simulated:
+            return {
+                "info": SIMULATION_INFO,
+                "currency": currency,
+                "kind": kind,
+                "type": order_type,
+            }
         uri = self.__CANCEL_ALL_BY_KIND_OR_TYPE
         params = {
             "currency": "",

--- a/tests/test_trading.py
+++ b/tests/test_trading.py
@@ -173,39 +173,39 @@ def test_instrument_margins_fetches_price_if_missing(mocker, trading):
     }
 
 
-def test_close_position_market(mocker, trading):
-    calls = record_requests(mocker, trading, response={})
-    trading.close_position("BTC-PERPETUAL")
+def test_close_position_market(mocker, live_trading):
+    calls = record_requests(mocker, live_trading, response={})
+    live_trading.close_position("BTC-PERPETUAL")
     uri, params = calls[0]
     assert uri == "/private/close_position"
     assert params == {"instrument_name": "BTC-PERPETUAL", "type": "market"}
 
 
-def test_close_position_limit(mocker, trading):
-    calls = record_requests(mocker, trading, response={})
-    trading.close_position("BTC-PERPETUAL", limit=42000.0)
+def test_close_position_limit(mocker, live_trading):
+    calls = record_requests(mocker, live_trading, response={})
+    live_trading.close_position("BTC-PERPETUAL", limit=42000.0)
     _, params = calls[0]
     assert params["type"] == "limit"
     assert params["price"] == 42000.0
 
 
-def test_cancel_orders_by_label_without_currency(mocker, trading):
-    calls = record_requests(mocker, trading, response={"cancelled": 1})
-    ret = trading.cancel_orders(label="my-label")
+def test_cancel_orders_by_label_without_currency(mocker, live_trading):
+    calls = record_requests(mocker, live_trading, response={"cancelled": 1})
+    ret = live_trading.cancel_orders(label="my-label")
     assert calls == [("/private/cancel_by_label", {"label": "my-label"})]
     assert ret == {"cancelled": 1}
 
 
-def test_cancel_orders_by_label_per_currency(mocker, trading):
-    calls = record_requests(mocker, trading, response={"cancelled": 1})
-    ret = trading.cancel_orders(label="my-label", currency=["BTC", "ETH"])
+def test_cancel_orders_by_label_per_currency(mocker, live_trading):
+    calls = record_requests(mocker, live_trading, response={"cancelled": 1})
+    ret = live_trading.cancel_orders(label="my-label", currency=["BTC", "ETH"])
     assert [params["currency"] for _, params in calls] == ["BTC", "ETH"]
     assert set(ret) == {"BTC", "ETH"}
 
 
-def test_cancel_orders_by_kind_and_type(mocker, trading):
-    calls = record_requests(mocker, trading, response={"cancelled": 2})
-    ret = trading.cancel_orders(currency="BTC", kind="option", order_type="limit")
+def test_cancel_orders_by_kind_and_type(mocker, live_trading):
+    calls = record_requests(mocker, live_trading, response={"cancelled": 2})
+    ret = live_trading.cancel_orders(currency="BTC", kind="option", order_type="limit")
     uri, params = calls[0]
     assert uri == "/private/cancel_all_by_kind_or_type"
     assert params == {"currency": "BTC", "kind": "option", "type": "limit"}
@@ -228,3 +228,48 @@ def test_get_orders_one_request_per_id(mocker, trading):
     df = trading.get_orders(["a", "b", "c"])
     assert [params["order_id"] for _, params in calls] == ["a", "b", "c"]
     assert len(df) == 3
+
+
+def test_close_position_simulated_does_not_call_api(mocker, trading):
+    calls = record_requests(mocker, trading)
+    mocker.patch.object(trading, "last_price", return_value=42000.0)
+    ret = trading.close_position("BTC-PERPETUAL")
+    assert calls == []
+    assert "SIMULATION" in ret["info"]
+    assert ret["instrument_name"] == "BTC-PERPETUAL"
+
+
+def test_close_position_simulated_uses_limit_price(mocker, trading):
+    record_requests(mocker, trading)
+    last_price = mocker.patch.object(trading, "last_price")
+    ret = trading.close_position("BTC-PERPETUAL", limit=41000.0)
+    assert ret["type"] == "limit"
+    assert ret["price"] == 41000.0
+    last_price.assert_not_called()
+
+
+def test_cancel_orders_simulated_does_not_call_api(mocker, trading):
+    calls = record_requests(mocker, trading)
+    ret = trading.cancel_orders(currency="BTC", kind="option")
+    assert calls == []
+    assert "SIMULATION" in ret["info"]
+
+
+def test_cancel_by_label_simulated_does_not_call_api(mocker, trading):
+    calls = record_requests(mocker, trading)
+    ret = trading.cancel_orders(label="my-label")
+    assert calls == []
+    assert "SIMULATION" in ret["info"]
+    assert ret["label"] == "my-label"
+
+
+def test_close_position_live_still_executes(mocker, live_trading):
+    calls = record_requests(mocker, live_trading, response={"ok": 1})
+    live_trading.close_position("BTC-PERPETUAL")
+    assert calls[0][0] == "/private/close_position"
+
+
+def test_cancel_orders_live_still_executes(mocker, live_trading):
+    calls = record_requests(mocker, live_trading, response={"ok": 1})
+    live_trading.cancel_orders(currency="BTC")
+    assert calls[0][0] == "/private/cancel_all_by_kind_or_type"


### PR DESCRIPTION
`self.simulated` was checked in exactly one place — `_order`. So a client built with the defaults (`simulated=True`, `env="prod"`) would refuse to place an order, yet happily execute:

- `close_position(...)` → real position closed on **production**
- `cancel_orders(...)` / cancel-by-label → real orders cancelled on **production**

Both submit live state changes, so simulation should cover them. Now they return a simulation result (`SIMULATION MODE - no trade executed`, with the parameters that would have been sent) and issue no request. `simulated=False` behavior is unchanged.

Also lifts the simulation-info string into a `SIMULATION_INFO` constant instead of repeating the literal.

## Tests

Six new tests: each of `close_position` (market + limit), `cancel_orders`, and cancel-by-label makes **no API call** when simulated, and both still execute when `simulated=False`.

Five existing tests asserted the live request shapes for these methods using the simulated fixture — they now use the `live_trading` fixture, which is what they were actually testing.

Companion to #98, which documents the current (dangerous) behavior; if both land, that README caveat should be dropped — I'll follow up.