### PR TITLE
fix: bound the temporarily-unavailable retry loop

### DIFF
--- a/deribit_wrapper/authentication.py
+++ b/deribit_wrapper/authentication.py
@@ -16,6 +16,11 @@ from .base import DeribitBase
 from .exceptions import DeribitClientWarning, ServiceUnavailable, RequestError
 from .utilities import ParamsType, ScopeType, seconds_to_hms
 
+# Bounded by default so a stalled venue cannot block a caller for an hour;
+# override per client via unavailable_max_attempts / unavailable_wait_seconds.
+UNAVAILABLE_MAX_ATTEMPTS = 5
+UNAVAILABLE_WAIT_SECONDS = 60
+
 
 class Authentication(DeribitBase):  # pylint: disable=too-many-instance-attributes
     """Authenticate against the Deribit API and issue JSON-RPC requests."""
@@ -47,6 +52,8 @@ class Authentication(DeribitBase):  # pylint: disable=too-many-instance-attribut
         self._token_expiry = None
         self._refresh_token = None
         self._http_session: Session | None = None
+        self.unavailable_max_attempts = UNAVAILABLE_MAX_ATTEMPTS
+        self.unavailable_wait_seconds = UNAVAILABLE_WAIT_SECONDS
 
     @property
     def client_id(self) -> str:
@@ -218,16 +225,20 @@ class Authentication(DeribitBase):  # pylint: disable=too-many-instance-attribut
     def _handle_temporarily_unavailable(
         self, uri: str, params: ParamsType, give_results: bool
     ) -> dict:
-        max_attempts = 60
+        max_attempts = self.unavailable_max_attempts
+        wait = self.unavailable_wait_seconds
         for i in range(max_attempts):
             print(
-                f"Temporarily unavailable. Waiting 1 minute [{i + 1}/{max_attempts}]..."
+                f"Temporarily unavailable. Waiting {seconds_to_hms(wait)} "
+                f"[{i + 1}/{max_attempts}]..."
             )
-            time.sleep(60)
+            time.sleep(wait)
             ret = self._request(uri, params, give_results=give_results)
             if ret.get("code") != 13028:
                 return ret
-        raise ServiceUnavailable("Service temporarily unavailable.")
+        raise ServiceUnavailable(
+            f"Service temporarily unavailable after {max_attempts} attempts."
+        )
 
     def _handle_settlement_in_progress(
         self, uri: str, params: ParamsType, give_results: bool

--- a/deribit_wrapper/authentication.py
+++ b/deribit_wrapper/authentication.py
@@ -222,14 +222,27 @@ class Authentication(DeribitBase):  # pylint: disable=too-many-instance-attribut
                 return self._request(uri, params, give_results=give_results)
         return {}
 
+    def _retry_budget(self) -> tuple[int, float]:
+        """Return the validated retry budget, rejecting misconfigured values."""
+        attempts = self.unavailable_max_attempts
+        wait = self.unavailable_wait_seconds
+        if not isinstance(attempts, int) or attempts < 1:
+            raise ValueError(
+                f"unavailable_max_attempts must be an integer >= 1, got {attempts!r}."
+            )
+        if not isinstance(wait, (int, float)) or wait < 0:
+            raise ValueError(
+                f"unavailable_wait_seconds must be a non-negative number, got {wait!r}."
+            )
+        return attempts, wait
+
     def _handle_temporarily_unavailable(
         self, uri: str, params: ParamsType, give_results: bool
     ) -> dict:
-        max_attempts = self.unavailable_max_attempts
-        wait = self.unavailable_wait_seconds
+        max_attempts, wait = self._retry_budget()
         for i in range(max_attempts):
             print(
-                f"Temporarily unavailable. Waiting {seconds_to_hms(wait)} "
+                f"Temporarily unavailable. Waiting {seconds_to_hms(int(wait))} "
                 f"[{i + 1}/{max_attempts}]..."
             )
             time.sleep(wait)

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -6,7 +6,11 @@ import pytest
 from dotenv import load_dotenv
 
 from deribit_wrapper.authentication import Authentication
-from deribit_wrapper.exceptions import DeribitClientWarning, RequestError
+from deribit_wrapper.exceptions import (
+    DeribitClientWarning,
+    RequestError,
+    ServiceUnavailable,
+)
 
 load_dotenv()
 
@@ -212,3 +216,35 @@ def test_close_releases_and_is_idempotent(auth_instance):
     assert auth_instance._http_session is None
     auth_instance.close()  # idempotent
     assert auth_instance._session is not session  # a new session is created lazily
+
+
+def test_temporarily_unavailable_is_bounded(auth_instance, mocker):
+    """Test that repeated 13028 responses give up instead of blocking forever."""
+    mocker.patch("time.sleep")
+    auth_instance.unavailable_max_attempts = 3
+    auth_instance.unavailable_wait_seconds = 0
+    with patch.object(
+        auth_instance, "_request", return_value={"code": 13028}
+    ) as mock_request:
+        with pytest.raises(ServiceUnavailable, match="3 attempts"):
+            auth_instance._handle_temporarily_unavailable("/private/x", {}, True)
+    assert mock_request.call_count == 3
+
+
+def test_temporarily_unavailable_returns_on_recovery(auth_instance, mocker):
+    """Test that the first non-13028 response is returned."""
+    mocker.patch("time.sleep")
+    auth_instance.unavailable_wait_seconds = 0
+    with patch.object(
+        auth_instance, "_request", side_effect=[{"code": 13028}, {"ok": True}]
+    ) as mock_request:
+        ret = auth_instance._handle_temporarily_unavailable("/private/x", {}, True)
+    assert ret == {"ok": True}
+    assert mock_request.call_count == 2
+
+
+def test_unavailable_defaults_are_bounded():
+    """Test that the default retry budget cannot block for an hour."""
+    auth = Authentication(env="test", client_id="id", client_secret="secret")
+    worst_case = auth.unavailable_max_attempts * auth.unavailable_wait_seconds
+    assert worst_case <= 600

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -248,3 +248,28 @@ def test_unavailable_defaults_are_bounded():
     auth = Authentication(env="test", client_id="id", client_secret="secret")
     worst_case = auth.unavailable_max_attempts * auth.unavailable_wait_seconds
     assert worst_case <= 600
+
+
+@pytest.mark.parametrize("bad", [0, -1, 2.5, "3", None])
+def test_retry_budget_rejects_bad_attempts(auth_instance, bad):
+    """Test that a misconfigured attempt count raises a clear error."""
+    auth_instance.unavailable_max_attempts = bad
+    with pytest.raises(ValueError, match="unavailable_max_attempts"):
+        auth_instance._retry_budget()
+
+
+@pytest.mark.parametrize("bad", [-1, "60", None])
+def test_retry_budget_rejects_bad_wait(auth_instance, bad):
+    """Test that a misconfigured wait raises a clear error."""
+    auth_instance.unavailable_wait_seconds = bad
+    with pytest.raises(ValueError, match="unavailable_wait_seconds"):
+        auth_instance._retry_budget()
+
+
+def test_retry_budget_accepts_float_wait(auth_instance):
+    """Test that a sub-second wait is allowed and formats without error."""
+    auth_instance.unavailable_wait_seconds = 0.5
+    assert auth_instance._retry_budget() == (
+        auth_instance.unavailable_max_attempts,
+        0.5,
+    )


### PR DESCRIPTION
`_handle_temporarily_unavailable` retried **60 times with `time.sleep(60)`** between attempts. When Deribit returns 13028 persistently, that blocks the calling thread for **up to a full hour**, uninterruptibly — the same shape as the fake 10-second abort window we removed from the `env` setter in #80.

- Default budget is now **5 attempts × 60s** (worst case 5 minutes).
- Configurable per client: `client.unavailable_max_attempts` / `client.unavailable_wait_seconds` — set them higher if you genuinely want to wait out a long outage.
- The `ServiceUnavailable` message now says how many attempts were made.
- The wait is reported via `seconds_to_hms` rather than a hardcoded "1 minute" that ignored the actual value.

## Tests

Three new tests (with `time.sleep` patched, so they're instant): the loop gives up after exactly N attempts and raises, it returns the first non-13028 response, and the shipped defaults can't exceed 10 minutes.

Left alone: `_handle_settlement_in_progress` (60 × 1s = 1 minute worst case) is a reasonable bound already.