### PR TITLE
perf: concatenate DataFrames once instead of per iteration

### DIFF
--- a/deribit_wrapper/account_management.py
+++ b/deribit_wrapper/account_management.py
@@ -84,12 +84,12 @@ class AccountManagement(MarketData):
             currency = self.currencies
         elif not isinstance(currency, list):
             currency = [currency]
-        df = pd.DataFrame()
+        frames = []
         for c in currency:
             params["currency"] = c
             r = self._request(uri, params)
-            r = {k: [v] for k, v in r.items()}
-            df = pd.concat([df, pd.DataFrame(r)], ignore_index=True)
+            frames.append(pd.DataFrame({k: [v] for k, v in r.items()}))
+        df = pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
         if "currency" in df.columns:
             cols = df.columns.tolist()
             cols = ["currency"] + [col for col in cols if col != "currency"]
@@ -341,12 +341,11 @@ class AccountManagement(MarketData):
             currency = [currency]
         if subaccount_id is not None:
             params["subaccount_id"] = subaccount_id
-        ret = pd.DataFrame()
+        frames = []
         for c in currency:
             params["currency"] = c
-            r = self._request(uri, params)
-            ret = pd.concat([ret, pd.DataFrame(r)], ignore_index=True)
-        return ret
+            frames.append(pd.DataFrame(self._request(uri, params)))
+        return pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
 
     def get_transaction_log(
         self,
@@ -368,7 +367,7 @@ class AccountManagement(MarketData):
             currency = [currency]
         params["start_timestamp"] = from_dt_to_ts(pd.to_datetime(start, utc=True))
         params["end_timestamp"] = from_dt_to_ts(pd.to_datetime(end, utc=True))
-        results = pd.DataFrame()
+        frames = []
         for q in query:
             if q is not None:
                 params["query"] = q
@@ -379,12 +378,12 @@ class AccountManagement(MarketData):
                 while continuation is not None:
                     ret = self._request(uri, params)
                     new_results = pd.DataFrame(ret["logs"])
-                    new_results_filtered = new_results.dropna(axis=1, how="all")
-                    results = pd.concat([results, new_results_filtered])
-                    if "profit_as_cashflow" in results.columns:
-                        results = results.astype({"profit_as_cashflow": bool})
+                    frames.append(new_results.dropna(axis=1, how="all"))
                     continuation = ret["continuation"]
                     params["continuation"] = continuation
+        results = pd.concat(frames) if frames else pd.DataFrame()
+        if "profit_as_cashflow" in results.columns:
+            results = results.astype({"profit_as_cashflow": bool})
         results.reset_index(drop=True, inplace=True)
         return results
 

--- a/deribit_wrapper/market_data.py
+++ b/deribit_wrapper/market_data.py
@@ -156,15 +156,14 @@ class MarketData(Authentication):
             currencies = self.currencies
         else:
             currencies = [currencies] if isinstance(currencies, str) else currencies
-        ret = pd.DataFrame()
+        frames = []
         for currency in currencies:
             params["currency"] = currency
             params["expired"] = False
-            r = self._request(uri, params)
-            ret = pd.concat([ret, pd.DataFrame(r)], ignore_index=True)
+            frames.append(pd.DataFrame(self._request(uri, params)))
             params["expired"] = True
-            r = self._request(uri, params)
-            ret = pd.concat([ret, pd.DataFrame(r)], ignore_index=True)
+            frames.append(pd.DataFrame(self._request(uri, params)))
+        ret = pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
         if not ret.empty:
             ret.drop_duplicates(subset=["instrument_name"], inplace=True)
             ret.sort_values(
@@ -363,7 +362,7 @@ class MarketData(Authentication):
         end_date = end_date or DEFAULT_END
         if assets is None:
             assets = self.get_instruments(as_list=True)
-        df = pd.DataFrame()
+        frames = []
         prefix = (
             f"{self.progress_bar_desc}: Market data"
             if self.progress_bar_desc
@@ -373,6 +372,7 @@ class MarketData(Authentication):
             ret = self.get_market_data_history(asset, start_date, end_date)
             ret["instrument_name"] = asset
             ret.set_index("instrument_name", append=True, inplace=True)
-            df = pd.concat([df, ret])
+            frames.append(ret)
+        df = pd.concat(frames) if frames else pd.DataFrame()
         df.sort_index(inplace=True)
         return df

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -390,3 +390,41 @@ def test_get_complete_market_book_covers_all_currencies(mocker, market_data):
 def test_get_market_book_both_args_raises(market_data):
     with pytest.raises(ValueError, match="not both"):
         market_data.get_market_book(currency="BTC", instrument="BTC-PERPETUAL")
+
+
+def test_get_market_data_concatenates_and_sorts(mocker, market_data):
+    def history(asset, start, end):
+        return pd.DataFrame(
+            {"close": [1.0, 2.0]},
+            index=pd.Index(
+                pd.to_datetime(["2024-01-02", "2024-01-01"]).date, name="date"
+            ),
+        )
+
+    mocker.patch.object(market_data, "get_market_data_history", side_effect=history)
+    df = market_data.get_market_data(assets=["ETH-PERPETUAL", "BTC-PERPETUAL"])
+    assert list(df.index.names) == ["date", "instrument_name"]
+    assert len(df) == 4
+    # sorted by the full index, so dates ascend and instruments group within them
+    assert df.index.tolist() == sorted(df.index.tolist())
+
+
+def test_get_market_data_single_asset(mocker, market_data):
+    mocker.patch.object(
+        market_data,
+        "get_market_data_history",
+        return_value=pd.DataFrame(
+            {"close": [1.0]},
+            index=pd.Index(pd.to_datetime(["2024-01-01"]).date, name="date"),
+        ),
+    )
+    df = market_data.get_market_data(assets=["BTC-PERPETUAL"])
+    assert len(df) == 1
+    assert df.index.get_level_values("instrument_name").tolist() == ["BTC-PERPETUAL"]
+
+
+def test_get_market_data_empty_asset_list(mocker, market_data):
+    history = mocker.patch.object(market_data, "get_market_data_history")
+    df = market_data.get_market_data(assets=[])
+    assert df.empty
+    history.assert_not_called()


### PR DESCRIPTION
Finishes the cleanup started in #84, which fixed only `get_market_book` because that was its scope. Six remaining sites built their result with `pd.concat` **inside** the loop, reallocating the entire frame every iteration — quadratic in the number of currencies or pagination pages:

- `market_data.get_instruments` (two concats per currency)
- `market_data.get_market_data` (one per instrument — the progress-bar loop, so the worst offender)
- `account_management.get_account_summary`
- `account_management.get_positions`
- `account_management.get_transaction_log` (per pagination page)

All now collect into a list and concatenate once, with an explicit empty-input branch so behavior is unchanged when nothing comes back.

One behavioral note: in `get_transaction_log` the `profit_as_cashflow` boolean cast now runs once after the concat instead of being re-applied to the growing frame on every page. Same result, less work.

Full suite passes, pylint 10/10.