### PR TITLE
fix: raise a clear error when an API key id is not found

### DIFF
--- a/deribit_wrapper/account_management.py
+++ b/deribit_wrapper/account_management.py
@@ -121,8 +121,14 @@ class AccountManagement(MarketData):
     def get_api_key(self, api_key_id: str) -> dict:
         """Return the API key with the given id; raises if no key matches."""
         keys = self.list_api_keys()
-        key = keys[keys["id"] == api_key_id].to_dict(orient="records")
-        return key[0]
+        matches = (
+            keys[keys["id"] == api_key_id].to_dict(orient="records")
+            if not keys.empty
+            else []
+        )
+        if not matches:
+            raise ValueError(f"API key {api_key_id} not found.")
+        return matches[0]
 
     def create_api_key(self, max_scope: str, name: str = None) -> dict:
         """Create an API key with the given maximum scope and optional name."""

--- a/deribit_wrapper/account_management.py
+++ b/deribit_wrapper/account_management.py
@@ -118,14 +118,12 @@ class AccountManagement(MarketData):
         df = pd.DataFrame(r)
         return df
 
-    def get_api_key(self, api_key_id: str) -> dict:
+    def get_api_key(self, api_key_id: int | str) -> dict:
         """Return the API key with the given id; raises if no key matches."""
         keys = self.list_api_keys()
-        matches = (
-            keys[keys["id"] == api_key_id].to_dict(orient="records")
-            if not keys.empty
-            else []
-        )
+        records = keys.to_dict(orient="records") if not keys.empty else []
+        # the API reports ids as integers, but accept the string form too
+        matches = [r for r in records if str(r.get("id")) == str(api_key_id)]
         if not matches:
             raise ValueError(f"API key {api_key_id} not found.")
         return matches[0]
@@ -139,7 +137,9 @@ class AccountManagement(MarketData):
         r = self._request(uri, params)
         return r
 
-    def edit_api_key(self, api_key_id: str, max_scope: str, name: str = None) -> dict:
+    def edit_api_key(
+        self, api_key_id: int | str, max_scope: str, name: str = None
+    ) -> dict:
         """Edit an API key's maximum scope and optional name."""
         uri = self.__EDIT_API_KEY
         params = {"id": api_key_id, "max_scope": max_scope}
@@ -148,21 +148,21 @@ class AccountManagement(MarketData):
         r = self._request(uri, params)
         return r
 
-    def enable_api_key(self, api_key_id: str) -> dict:
+    def enable_api_key(self, api_key_id: int | str) -> dict:
         """Enable the API key with the given id."""
         uri = self.__ENABLE_API_KEY
         params = {"id": api_key_id}
         r = self._request(uri, params)
         return r
 
-    def disable_api_key(self, api_key_id: str) -> dict:
+    def disable_api_key(self, api_key_id: int | str) -> dict:
         """Disable the API key with the given id."""
         uri = self.__DISABLE_API_KEY
         params = {"id": api_key_id}
         r = self._request(uri, params)
         return r
 
-    def remove_api_key(self, api_key_id: str) -> dict:
+    def remove_api_key(self, api_key_id: int | str) -> dict:
         """Remove the API key with the given id."""
         uri = self.__REMOVE_API_KEY
         params = {"id": api_key_id}

--- a/tests/test_account_management.py
+++ b/tests/test_account_management.py
@@ -299,3 +299,16 @@ def test_check_if_margin_model_change_is_possible(mocker, account):
     not_ok = pd.DataFrame([[1.5, 0.3]], columns=columns)
     mocker.patch.object(account, "_change_margin_model", return_value=not_ok)
     assert not account.check_if_margin_model_change_is_possible("cross_pm")
+
+
+def test_get_api_key_not_found_raises_value_error(mocker, account):
+    keys = pd.DataFrame([{"id": 1, "name": "key1"}])
+    mocker.patch.object(account, "list_api_keys", return_value=keys)
+    with pytest.raises(ValueError, match="API key 99 not found"):
+        account.get_api_key(99)
+
+
+def test_get_api_key_empty_list_raises_value_error(mocker, account):
+    mocker.patch.object(account, "list_api_keys", return_value=pd.DataFrame())
+    with pytest.raises(ValueError, match="not found"):
+        account.get_api_key(1)

--- a/tests/test_account_management.py
+++ b/tests/test_account_management.py
@@ -312,3 +312,9 @@ def test_get_api_key_empty_list_raises_value_error(mocker, account):
     mocker.patch.object(account, "list_api_keys", return_value=pd.DataFrame())
     with pytest.raises(ValueError, match="not found"):
         account.get_api_key(1)
+
+
+def test_get_api_key_accepts_string_id_for_integer_key(mocker, account):
+    keys = pd.DataFrame([{"id": 1, "name": "key1"}, {"id": 2, "name": "key2"}])
+    mocker.patch.object(account, "list_api_keys", return_value=keys)
+    assert account.get_api_key("2") == {"id": 2, "name": "key2"}


### PR DESCRIPTION
`get_api_key` filtered the key list and returned `key[0]` unconditionally, so an unknown id surfaced as a bare `IndexError: list index out of range` — leaking the implementation and telling the caller nothing. With no keys at all it would have failed even earlier, on the `keys["id"]` column lookup.

Now raises `ValueError(f"API key {api_key_id} not found.")`, consistent with how `get_subaccount` already reports a missing subaccount, and handles the empty-frame case.

Two tests: unknown id among existing keys, and an empty key list.

Follow-up to the thread on #88, where this was flagged but deliberately left out of a docs-only PR.